### PR TITLE
fix: add validation for storage name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -178,11 +178,16 @@ variable "pi_storage_config" {
 
   validation {
     condition = var.pi_storage_config != null ? (
-      alltrue([for config in var.pi_storage_config : (
-        (config.name != "" && config.count != "" && config.tier != "" && config.mount != "") || (config.name == "" && config.count == "" && config.tier == "" && config.mount == "")
-      )])
-    ) : var.pi_storage_config == null ? true : false
-    error_message = "One of the storage config has invalid value, probably an empty string'"
+      alltrue([
+        for config in var.pi_storage_config : (
+          (config.name != "" && config.count != "" && config.tier != "" && config.mount != "") ||
+          (config.name == "" && config.count == "" && config.tier == "" && config.mount == "")
+        )
+      ]) &&
+      length(distinct([for config in var.pi_storage_config : config.name])) == length(var.pi_storage_config)
+    ) : true
+
+    error_message = "One of the storage configs has an invalid value (e.g., an empty string), or duplicate 'name' values exist."
   }
 }
 
@@ -229,7 +234,7 @@ variable "pi_instance_init_linux" {
     bastion_host_ip    = ""
     ansible_host_or_ip = ""
     ssh_private_key    = <<-EOF
-EOF
+ EOF
   }
 
   validation {


### PR DESCRIPTION
### Description

Storage name must not be same. Added a validation block to handle this

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
